### PR TITLE
Overhaul of grid code in mock libavr32; add 256, support older protocols, selectable protocol/theme on virtual grids, graphics updates, bugfixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -94,6 +94,7 @@
         "codecvt": "cpp",
         "condition_variable": "cpp",
         "regex": "cpp",
-        "shared_mutex": "cpp"
+        "shared_mutex": "cpp",
+        "mock_hardware_api.h": "c"
     }
 }

--- a/firmware/mock_hardware/common/ftdi.c
+++ b/firmware/mock_hardware/common/ftdi.c
@@ -4,11 +4,6 @@
 #include "events.h"
 #include <string.h>
 
-#define FTDI_STRING_MAX_LEN 64
-char manufacturer_string[FTDI_STRING_MAX_LEN];
-char product_string[FTDI_STRING_MAX_LEN];
-char serial_string[FTDI_STRING_MAX_LEN];
-
 u8* current_ftdi_message;
 u32 current_ftdi_message_length;
 u8 ftdiConnect;
@@ -23,38 +18,9 @@ void ftdi_write(u8* data, u32 bytes)
     hardware_writeSerial_internal(FTDI_BUS, data, bytes);
 }
 
-void mock_ftdi_change(u8 plug, const char* manstr, const char* prodstr, const char* serstr)
-{
-    event_t e;
-    if (plug)
-    {
-        ftdiConnect = 1;
-        e.type = kEventFtdiConnect;
-
-        if (manstr != NULL && strlen(manstr) < FTDI_STRING_MAX_LEN)
-        {
-            strcpy(manufacturer_string, manstr);
-        }
-        if (prodstr != NULL && strlen(prodstr) < FTDI_STRING_MAX_LEN)
-        {
-            strcpy(product_string, prodstr);
-        }
-        if (serstr != NULL && strlen(serstr) < FTDI_STRING_MAX_LEN)
-        {
-            strcpy(serial_string, serstr);
-        }
-    }
-    else
-    {
-        ftdiConnect = 0;
-        e.type = kEventFtdiDisconnect;
-    }
-    event_post(&e);
-}
-
 void ftdi_setup(void)
 {
-    check_monome_device_desc(manufacturer_string, product_string, serial_string);
+
 }
 
 u8* ftdi_rx_buf(void)

--- a/firmware/mock_hardware/common/monome.c
+++ b/firmware/mock_hardware/common/monome.c
@@ -978,4 +978,13 @@ void monome_setup_mext() {
   monome_connect_write_event();
 }
 
-
+void mock_setup_ftdi_funcs()
+{
+    serial_read = &ftdi_read;
+    serial_write = &ftdi_write;
+    tx_busy = &ftdi_tx_busy;
+    rx_busy = &ftdi_rx_busy;
+    rx_buf = &ftdi_rx_buf;
+    rx_bytes = &ftdi_rx_bytes;
+    serial_connected = &ftdi_connected;
+}

--- a/firmware/mock_hardware/mock_hardware_api.h
+++ b/firmware/mock_hardware/mock_hardware_api.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+
 typedef enum
 {
     FTDI_BUS,
@@ -33,7 +34,7 @@ MOCK_API(void, initSerial, ());
 MOCK_API(void, resetSerialIn, ());
 MOCK_API(void, resetSerialOut, ());
 
-MOCK_API(void, serialConnectionChange, (serial_bus_t bus, uint8_t connected, const char* manufacturer, const char* product, const char* serial));
+MOCK_API(void, serialConnectionChange, (serial_bus_t bus, bool connected, uint8_t protocol, uint8_t width, uint8_t height));
 
 MOCK_API(void, readSerial, (serial_bus_t bus, uint8_t** pbuf, uint32_t* pcount));
 MOCK_API(void, writeSerial, (serial_bus_t bus, uint8_t* buf, uint32_t byteCount));

--- a/lib/serialosc/SerialOsc.cpp
+++ b/lib/serialosc/SerialOsc.cpp
@@ -328,7 +328,8 @@ void SerialOsc::ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointNa
                 device->prefix = "/" + device->prefix;
             }
 
-            listener->deviceFound(device);
+            // wait until after size message recieved -MD
+            // listener->deviceFound(device);
             sendDeviceInfoMessage(device->port);
 
             sendDevicePrefixMessage(port);
@@ -363,6 +364,9 @@ void SerialOsc::ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointNa
                 auto device = *deviceIterator;
                 device->width = (iter++)->AsInt32();
                 device->height = (iter++)->AsInt32();
+
+                // wait to notify listeners here, after size is known -MD
+                listener->deviceFound(device);
             }
         }
         else if (address == "/sys/rotation")

--- a/plugin.json
+++ b/plugin.json
@@ -75,6 +75,14 @@
       "tags": [
         "controller"
       ]
+    },
+    {
+      "slug": "grid256",
+      "name": "grid 256",
+      "description": "",
+      "tags": [
+        "controller"
+      ]
     }
   ]
 }

--- a/src/common/FirmwareManager.cpp
+++ b/src/common/FirmwareManager.cpp
@@ -293,11 +293,11 @@ void FirmwareManager::setADC(int channel, uint16_t value)
     }
 }
 
-void FirmwareManager::serialConnectionChange(serial_bus_t bus, uint8_t connected, const char* manufacturer, const char* product, const char* serial)
+void FirmwareManager::serialConnectionChange(serial_bus_t bus, bool connected, uint8_t protocol, uint8_t width, uint8_t height)
 {
     if (impl)
     {
-        return impl->fw_fn_hardware_serialConnectionChange(bus, connected, manufacturer, product, serial);
+        return impl->fw_fn_hardware_serialConnectionChange(bus, connected, protocol, width, height);
     }
 }
 

--- a/src/common/LibAVR32Module.cpp
+++ b/src/common/LibAVR32Module.cpp
@@ -23,7 +23,7 @@ void LibAVR32Module::gridConnected(Grid* newConnection)
 {
     if (gridConnection != nullptr)
     {
-        //firmware.serialConnectionChange(FTDI_BUS, 0, NULL, NULL, NULL);
+        firmware.serialConnectionChange(FTDI_BUS, false, 0, 0, 0);
     }
 
     gridConnection = newConnection;
@@ -32,30 +32,15 @@ void LibAVR32Module::gridConnected(Grid* newConnection)
         std::string id = gridConnection->getDevice().id;
         lastConnectedDeviceId = id;
 
-        std::string wide_id;
-        for (size_t i = 0; i < id.length(); i++)
-        {
-            if (i == 1 && id[1] == 'v')
-                i++;
-
-            wide_id.append(id, i, 1);
-            wide_id.append(" ");
-        }
-
-        firmware.serialConnectionChange(FTDI_BUS, 1, "m o n o m e", "p r o d u c t", wide_id.c_str());
-
-        uint8_t buf[6] = { 0, 1, 0, 0, 0, 0 };
-        buf[2] = (gridConnection->getDevice().width * gridConnection->getDevice().height) / 64;
-        firmware.writeSerial(FTDI_BUS, buf, 6);
-        uint8_t buf2[6] = { 0, 0, 0, 0, 0, 0 };
-        firmware.writeSerial(FTDI_BUS, buf2, 6);
+        auto d = gridConnection->getDevice();
+        firmware.serialConnectionChange(FTDI_BUS, true, d.protocol, d.width, d.height);
     }
 }
 
 void LibAVR32Module::gridDisconnected()
 {
     gridConnection = nullptr;
-    //firmware.serialConnectionChange(FTDI_BUS, 0, NULL, NULL, NULL);
+    firmware.serialConnectionChange(FTDI_BUS, false, 0, 0, 0);
 }
 
 void LibAVR32Module::gridButtonEvent(int x, int y, bool state)

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -32,8 +32,9 @@ void init(Plugin* p)
     Model* modelTeletypeExpander = createModel<TTExpanderModule, TTExpanderWidget>("teletype-expander");
     Model* modelAnsible = createModel<AnsibleModule, AnsibleWidget>("ansible");
 
-    Model* modelGrid128 = createModel<VirtualGridModuleTemplate<16, 8, 5>, VirtualGridWidgetTemplate<16, 8, 5>>("grid128");
-    Model* modelGrid64 = createModel<VirtualGridModuleTemplate<8, 8, 5>, VirtualGridWidgetTemplate<8, 8, 5>>("grid64");
+    Model* modelGrid128 = createModel<VirtualGridModuleTemplate<16, 8>, VirtualGridWidgetTemplate<16, 8>>("grid128");
+    Model* modelGrid64 = createModel<VirtualGridModuleTemplate<8, 8>, VirtualGridWidgetTemplate<8, 8>>("grid64");
+    Model* modelGrid256 = createModel<VirtualGridModuleTemplate<16, 16>, VirtualGridWidgetTemplate<16, 16>>("grid256");
 
     Model* modelFaderbank = createModel<FaderbankModule, FaderbankWidget>("faderbank");
 
@@ -47,6 +48,7 @@ void init(Plugin* p)
 
     p->addModel(modelGrid128);
     p->addModel(modelGrid64);
+    p->addModel(modelGrid256);
 
     p->addModel(modelFaderbank);
 

--- a/src/virtualgrid/VirtualGridKey.hpp
+++ b/src/virtualgrid/VirtualGridKey.hpp
@@ -1,0 +1,143 @@
+#include "rack.hpp"
+#include "VirtualGridTheme.hpp"
+
+struct VirtualGridKey : rack::app::ParamWidget
+{
+    uint8_t* ledAddress;
+    int index;
+    GridTheme* theme;
+
+    typedef enum
+    {
+        OFF,
+        PRESSED,
+        HELD
+    } KeyPressState;
+
+    VirtualGridKey()
+    : ledAddress(nullptr)
+    , theme(nullptr)
+    {
+    }
+
+    VirtualGridWidget* getGrid()
+    {
+        return dynamic_cast<VirtualGridWidget*>(parent);
+    }
+
+    void setKeyAddress(uint8_t* ledByte)
+    {
+        ledAddress = ledByte;
+    }
+
+    void draw(const DrawArgs& args) override
+    {
+        auto vg = args.vg;
+        uint8_t val = ledAddress != NULL ? *ledAddress : 0;
+
+        NVGcolor color1, color2;
+        levelToGradient(
+            theme ? *theme : GridTheme::Yellow, 
+            val,
+            &color1, 
+            &color2
+        );
+
+        if (paramQuantity && paramQuantity->getValue() == HELD)
+        {
+            nvgBeginPath(vg);
+            nvgRoundedRect(vg, -3, -3, box.size.x + 6, box.size.y + 6, 6);
+            nvgFillColor(vg, nvgRGB(180, 180, 0));
+            nvgFill(vg);
+        }
+
+        nvgBeginPath(vg);
+        auto paint = nvgBoxGradient(vg, 0, 0, box.size.x, box.size.y, box.size.x * 0.4, box.size.x * 1.2, color1, color2);
+        nvgRoundedRect(vg, 0, 0, box.size.x, box.size.y, 4);
+        if (val > 0)
+        {
+            nvgFillPaint(vg, paint);
+        }
+        else
+        {
+            nvgFillColor(vg, nvgRGB(0, 0, 0));
+        }
+        nvgFill(vg);
+    }
+
+    void beginPress()
+    {
+        if (paramQuantity)
+        {
+            float value = paramQuantity->getValue();
+
+            if ((APP->window->getMods() & RACK_MOD_MASK) == RACK_MOD_CTRL && value != HELD)
+            {
+                // hold key down
+                paramQuantity->setValue(HELD);
+            }
+            else
+            {
+                paramQuantity->setValue(PRESSED);
+            }
+        }
+    }
+
+    void endPress()
+    {
+        if (paramQuantity)
+        {
+            if (paramQuantity->getValue() != HELD)
+            {
+                paramQuantity->setValue(OFF);
+            }
+        }
+    }
+
+    void onButton(const rack::event::Button& e) override
+    {
+        if (e.button != GLFW_MOUSE_BUTTON_LEFT)
+        {
+            return;
+        }
+        e.consume(this);
+
+        if (e.action == GLFW_PRESS)
+        {
+            beginPress();
+        }
+        else
+        {
+            endPress();
+        }
+    }
+
+    void onDragStart(const rack::event::DragStart& e) override
+    {
+        beginPress();
+    }
+
+    void onDragEnd(const rack::event::DragEnd& e) override
+    {
+        if (e.getTarget() == nullptr || e.getTarget()->parent == this->parent)
+        {
+            endPress();
+        }
+    }
+
+    void onDragLeave(const rack::event::DragLeave& e) override
+    {
+        if (e.origin->parent == this->parent)
+        {
+            endPress();
+        }
+    }
+
+    void onDragEnter(const rack::event::DragEnter& e) override
+    {
+        if (e.origin->parent == this->parent)
+        {
+            beginPress();
+        }
+    }
+};

--- a/src/virtualgrid/VirtualGridModule.cpp
+++ b/src/virtualgrid/VirtualGridModule.cpp
@@ -10,7 +10,8 @@ VirtualGridModule::VirtualGridModule(unsigned w, unsigned h)
         for (unsigned i = 0; i < w; i++)
         {
             int n = i + j * w;
-            configParam(n, 0.0, 2.0, 0.0);
+            // set an infinite bound so it won't be serialized [and also won't be midi mappable ): ]
+            configParam(n, 0.0, INFINITY, 0.0);
         }
     }
 
@@ -44,10 +45,11 @@ void VirtualGridModule::process(const ProcessArgs& args)
         for (int j = 0; j < device.height; j++)
         {
             int n = i + (j * device.width);
-            if ((params[n].value > 0) != pressedState[n])
+            bool state = params[n].getValue() > 0;
+            if (state != pressedState[n])
             {
-                GridConnectionManager::get()->dispatchButtonMessage(&this->device, i, j, params[n].value > 0);
-                pressedState[n] = params[n].value > 0;
+                pressedState[n] = state;
+                GridConnectionManager::get()->dispatchButtonMessage(&this->device, i, j, pressedState[n]);
             }
             lights[n].setBrightness(ledBuffer[n] / 255.0);
         }
@@ -96,4 +98,5 @@ void VirtualGridModule::updateQuadrant(int x_offset, int y_offset, uint8_t* leds
 void VirtualGridModule::clearAll()
 {
     memset(ledBuffer, 0, sizeof(uint8_t) * GRID_MAX_SIZE);
+    memset(pressedState, 0, sizeof(uint8_t) * GRID_MAX_SIZE);
 }

--- a/src/virtualgrid/VirtualGridModule.hpp
+++ b/src/virtualgrid/VirtualGridModule.hpp
@@ -1,8 +1,10 @@
 #pragma once
 #include "GridConnection.hpp"
+#include "VirtualGridTheme.hpp"
 #include "rack.hpp"
 
 #define GRID_MAX_SIZE 256
+
 
 struct VirtualGridModule : rack::Module, Grid
 {
@@ -25,11 +27,13 @@ struct VirtualGridModule : rack::Module, Grid
     void updateQuadrant(int x_offset, int y_offset, uint8_t* leds) override;
     void clearAll() override;
 
+    GridTheme theme;
+
 protected:
     bool firstStep;
 };
 
-template <unsigned width, unsigned height, unsigned modelIndex>
+template <unsigned width, unsigned height>
 struct VirtualGridModuleTemplate : VirtualGridModule
 {
     VirtualGridModuleTemplate()

--- a/src/virtualgrid/VirtualGridTheme.cpp
+++ b/src/virtualgrid/VirtualGridTheme.cpp
@@ -1,0 +1,25 @@
+#include "VirtualGridTheme.hpp"
+
+void levelToGradient(GridTheme theme, uint8_t level, NVGcolor* color1, NVGcolor* color2)
+{
+    if (theme == GridTheme::Red) 
+    {
+        if (color1) *color1 = nvgRGB(level * 16 + 15, level * 11 + 10, level * 2);
+        if (color2) *color2 = nvgRGB(level * 16 + 15, level * 5  + 10,  level * 1);
+    }
+    else if (theme == GridTheme::Orange)
+    {
+        if (color1) *color1 = nvgRGB(level * 16 + 15, level * 13 + 15, level * 5);
+        if (color2) *color2 = nvgRGB(level * 14 + 15, level * 7 + 10,  level * 3);
+    }
+    else if (theme == GridTheme::White)
+    {
+        if (color1) *color1 = nvgRGB(level * 11 + 90, level * 11 + 90, level * 8 + 96);
+        if (color2) *color2 = nvgRGB(level * 9 + 48, level * 9 + 49, level * 12 + 54);
+    }
+    else // if (theme == GridTheme::Yellow)
+    {
+        if (color1) *color1 = nvgRGB(level * 11 + 90, level * 10 + 63, level * 7 + 42);
+        if (color2) *color2 = nvgRGB(level * 10 + 48, level * 9 + 41, level * 3 + 12);
+    }
+}

--- a/src/virtualgrid/VirtualGridTheme.hpp
+++ b/src/virtualgrid/VirtualGridTheme.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include "rack.hpp"
+
+typedef enum
+{
+    Red,
+    Orange,
+    Yellow,
+    White,
+    NUM_THEMES
+} GridTheme;
+
+void levelToGradient(GridTheme theme, uint8_t level, NVGcolor* color1, NVGcolor* color2);

--- a/src/virtualgrid/VirtualGridWidget.cpp
+++ b/src/virtualgrid/VirtualGridWidget.cpp
@@ -1,4 +1,6 @@
 #include "VirtualGridWidget.hpp"
+#include "VirtualGridKey.hpp"
+#include "VirtualGridTheme.hpp"
 #include "VirtualGridModule.hpp"
 #include "window.hpp"
 
@@ -8,156 +10,6 @@
 
 using namespace rack;
 
-struct MonomeKey : rack::app::ParamWidget
-{
-    uint8_t* ledAddress;
-    int index;
-    GridTheme theme;
-
-    typedef enum
-    {
-        OFF,
-        PRESSED,
-        HELD
-    } KeyPressState;
-
-    MonomeKey()
-        : ledAddress(NULL)
-    {
-    }
-
-    VirtualGridWidget* getGrid()
-    {
-        return dynamic_cast<VirtualGridWidget*>(parent);
-    }
-
-    void setKeyAddress(uint8_t* ledByte)
-    {
-        ledAddress = ledByte;
-    }
-
-    void draw(const DrawArgs& args) override
-    {
-        auto vg = args.vg;
-        uint8_t val = ledAddress != NULL ? *ledAddress : 0;
-        NVGcolor color1 = nvgRGB(val * 11 + 90, val * 11 + 63, val * 8 + 48);
-        NVGcolor color2 = nvgRGB(val * 12 + 48, val * 12 + 31, val * 4 + 16);
-
-        if (theme == MonoRed)
-        {
-            color1 = val > 0 ? nvgRGB(240, 140, 30) : nvgRGB(0, 0, 0);
-            color2 = val > 0 ? nvgRGB(250, 60, 20) : nvgRGB(0, 0, 0);
-        }
-
-        if (paramQuantity && paramQuantity->getValue() == HELD)
-        {
-            nvgBeginPath(vg);
-            nvgRoundedRect(vg, -3, -3, box.size.x + 6, box.size.y + 6, 6);
-            nvgFillColor(vg, nvgRGB(180, 180, 0));
-            nvgFill(vg);
-        }
-
-        nvgBeginPath(vg);
-        auto paint = nvgBoxGradient(vg, 0, 0, box.size.x, box.size.y, box.size.x * 0.4, box.size.x * 1.2, color1, color2);
-        nvgRoundedRect(vg, 0, 0, box.size.x, box.size.y, 4);
-        if (val > 0)
-        {
-            nvgFillPaint(vg, paint);
-        }
-        else
-        {
-            nvgFillColor(vg, nvgRGB(0, 0, 0));
-        }
-        nvgFill(vg);
-
-        /*
-        std::stringstream label;
-        //label << index;
-        label << ((uint64_t)ledAddress & 0xff);
-        nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
-        nvgFillColor(vg, nvgRGB(0, 0, 0));
-        nvgText(vg, box.size.x / 2, box.size.y / 2, label.str().c_str(), NULL);
-        nvgFillColor(vg, nvgRGB(255, 255, 255));
-        nvgText(vg, box.size.x / 2 - 1, box.size.y / 2 - 1, label.str().c_str(), NULL);
-        */
-    }
-
-    void beginPress()
-    {
-        if (paramQuantity)
-        {
-            float value = paramQuantity->getValue();
-
-            if ((APP->window->getMods() & RACK_MOD_MASK) == RACK_MOD_CTRL && value != HELD)
-            {
-                // hold key down
-                paramQuantity->setValue(HELD);
-            }
-            else
-            {
-                paramQuantity->setValue(PRESSED);
-            }
-        }
-    }
-
-    void endPress()
-    {
-        if (paramQuantity)
-        {
-            if (paramQuantity->getValue() != HELD)
-            {
-                paramQuantity->setValue(OFF);
-            }
-        }
-    }
-
-    void onButton(const rack::event::Button& e) override
-    {
-        if (e.button != GLFW_MOUSE_BUTTON_LEFT)
-        {
-            return;
-        }
-        e.consume(this);
-
-        if (e.action == GLFW_PRESS)
-        {
-            beginPress();
-        }
-        else
-        {
-            endPress();
-        }
-    }
-
-    void onDragStart(const rack::event::DragStart& e) override
-    {
-        beginPress();
-    }
-
-    void onDragEnd(const rack::event::DragEnd& e) override
-    {
-        if (e.getTarget() == nullptr || e.getTarget()->parent == this->parent) 
-        {
-            endPress();
-        }
-    }
-
-    void onDragLeave(const rack::event::DragLeave& e) override
-    {
-        if (e.origin->parent == this->parent)
-        {
-            endPress();
-        }
-    }
-
-    void onDragEnter(const rack::event::DragEnter& e) override
-    {
-        if (e.origin->parent == this->parent) 
-        {
-            beginPress();
-        }
-    }
-};
 
 std::string getUniqueVirtualDeviceId(std::string prefix)
 {
@@ -194,27 +46,35 @@ std::string getUniqueVirtualDeviceId(std::string prefix)
     }
 }
 
-VirtualGridWidget::VirtualGridWidget(VirtualGridModule* module, unsigned w, unsigned h, unsigned model)
+VirtualGridWidget::VirtualGridWidget(VirtualGridModule* module, unsigned w, unsigned h)
 {
     setModule(module);
-
-    if (model > 5)
-    {
-        model = 5;
-    }
-    std::string models[6] = { "mv40h", "mv64-", "mv128-", "mv256-", "mv512", "mv" };
-
     if (module)
     {
-        module->device.id = getUniqueVirtualDeviceId(models[model]);
+        module->device.id = getUniqueVirtualDeviceId("virt");
     }
 
-    theme = model == 5 ? VariYellow : MonoRed;
+    float rackWidth = 0;
+    if (w == h)
+    {
+        rackWidth = 375;
+        margins.x = 13.5;
+        margins.y = 16;
 
-    box.size = Vec(43.125 * w + 45, 380);
+    }
+    else if (w == 2 * h)
+    {
+        rackWidth = 735;
+        margins.x = 16;
+        margins.y = 16;
+    }
+    else
+    {
+        FATAL("Unsupported grid size");
+        assert(0);
+    }
 
-    margins.x = 16;
-    margins.y = 16;
+    box.size = Vec(rackWidth, 380);
 
     // create an opaque child underneath the keys to defeat module dragging in between the buttons
     auto gridZone = new OpaqueWidget();
@@ -234,14 +94,14 @@ VirtualGridWidget::VirtualGridWidget(VirtualGridModule* module, unsigned w, unsi
             float y = margins.y + j * (button_size + spacing);
             int n = i + j * w;
 
-            MonomeKey* key = (MonomeKey*)createParam<MonomeKey>(Vec(x, y), module, n);
+            VirtualGridKey* key = (VirtualGridKey*)createParam<VirtualGridKey>(Vec(x, y), module, n);
             if (module)
             {
                 key->setKeyAddress(module->ledBuffer + i + j * 16);
+                key->theme = &(module->theme);
             }
             key->box.size = Vec(button_size, button_size);
             key->index = n;
-            key->theme = theme;
             addParam(key);
         }
     }
@@ -266,7 +126,7 @@ void VirtualGridWidget::clearHeldKeys()
     {
         if (p->paramQuantity)
         {
-            p->paramQuantity->setValue(MonomeKey::OFF);
+            p->paramQuantity->setValue(VirtualGridKey::OFF);
         }
     }
 }
@@ -295,14 +155,72 @@ struct GridReleaseHeldKeysItem : MenuItem
     VirtualGridWidget* grid;
     void onAction(const event::Action& e) override
     {
-        grid->clearHeldKeys();
+        if (grid) 
+        {
+            grid->clearHeldKeys();
+        }
     }
 };
 
-void VirtualGridWidget::appendContextMenu(Menu* menu)
+struct GridThemeItem : MenuItem
+{
+    VirtualGridModule* module;
+    GridTheme theme;
+    
+    GridThemeItem(VirtualGridModule* module, std::string str, GridTheme theme) 
+    : module(module), theme(theme) {
+        text = str;
+        rightText = (module->theme == theme) ? CHECKMARK_STRING : "";
+    };
+
+    void onAction(const event::Action& e) override
+    {
+        if (module)
+        {
+            module->theme = theme;
+        }
+    }
+};
+
+struct GridProtocolItem : MenuItem
+{
+    VirtualGridModule* module;
+    MonomeProtocol protocol;
+
+    GridProtocolItem(VirtualGridModule* module, std::string str, MonomeProtocol protocol)
+     : module(module), protocol(protocol) {
+        text = str;
+        rightText = (module->device.protocol == protocol) ? CHECKMARK_STRING : "";
+    };
+
+    void onAction(const event::Action& e) override
+    {
+        if (module && protocol != module->device.protocol) 
+        {
+            GridConnectionManager::get()->deregisterGrid(module->device.id, false);
+            module->device.protocol = protocol;
+            GridConnectionManager::get()->registerGrid(module);
+        }
+    }
+};
+
+void
+VirtualGridWidget::appendContextMenu(Menu* menu)
 {
     VirtualGridModule* grid = dynamic_cast<VirtualGridModule*>(module);
     assert(grid);
+
+    menu->addChild(construct<MenuLabel>());
+    menu->addChild(construct<MenuLabel>(&MenuLabel::text, "Theme"));
+    menu->addChild(new GridThemeItem(grid, "\tRed", GridTheme::Red));
+    menu->addChild(new GridThemeItem(grid, "\tOrange", GridTheme::Orange));
+    menu->addChild(new GridThemeItem(grid, "\tYellow", GridTheme::Yellow));
+    menu->addChild(new GridThemeItem(grid, "\tWhite", GridTheme::White));
+    menu->addChild(construct<MenuLabel>());
+    menu->addChild(construct<MenuLabel>(&MenuLabel::text, "Protocol"));
+    menu->addChild(new GridProtocolItem(grid, "\t40h", PROTOCOL_40H));
+    menu->addChild(new GridProtocolItem(grid, "\tSeries", PROTOCOL_SERIES));
+    menu->addChild(new GridProtocolItem(grid, "\tMext", PROTOCOL_MEXT));
 
     menu->addChild(construct<MenuLabel>());
     menu->addChild(construct<GridReleaseHeldKeysItem>(&MenuItem::text, "Release Held Keys", &MenuItem::rightText, "Ctrl+Click", &GridReleaseHeldKeysItem::grid, this));

--- a/src/virtualgrid/VirtualGridWidget.hpp
+++ b/src/virtualgrid/VirtualGridWidget.hpp
@@ -25,8 +25,6 @@ struct VirtualGridWidget : rack::app::ModuleWidget
 
 protected:
     friend struct MonomeKey;
-    bool isDraggingKeys;
-    std::unordered_set<MonomeKey*> keysTouchedThisDrag;
 
     rack::Vec margins;
     GridTheme theme;

--- a/src/virtualgrid/VirtualGridWidget.hpp
+++ b/src/virtualgrid/VirtualGridWidget.hpp
@@ -1,20 +1,13 @@
 #include "rack.hpp"
-#include <unordered_set>
 
 #pragma once
 
-typedef enum
-{
-    MonoRed,
-    VariYellow
-} GridTheme;
-
-struct MonomeKey;
+struct VirtualGridKey;
 struct VirtualGridModule;
 
 struct VirtualGridWidget : rack::app::ModuleWidget
 {
-    VirtualGridWidget(VirtualGridModule* module, unsigned w, unsigned h, unsigned model);
+    VirtualGridWidget(VirtualGridModule* module, unsigned w, unsigned h);
 
     void draw(const DrawArgs& args) override;
     void onDragEnter(const rack::event::DragEnter& e) override;
@@ -24,17 +17,15 @@ struct VirtualGridWidget : rack::app::ModuleWidget
     void appendContextMenu(rack::ui::Menu* menu) override;
 
 protected:
-    friend struct MonomeKey;
-
+    friend struct VirtualGridKey;
     rack::Vec margins;
-    GridTheme theme;
 };
 
-template <unsigned width, unsigned height, unsigned modelIndex>
+template <unsigned width, unsigned height>
 struct VirtualGridWidgetTemplate : VirtualGridWidget
 {
     VirtualGridWidgetTemplate(VirtualGridModule* module)
-        : VirtualGridWidget(module, width, height, modelIndex)
+        : VirtualGridWidget(module, width, height)
     {
     }
 };


### PR DESCRIPTION
* add virtual grid 256 module (#28)
* fix 64/256 margins
* separate notion of grid color theme from grid protocol
* right-click menu options on virtual grids to choose color theme and protocol
* support older grid protocols again (#44)
* fix mock event object lifetimes (probably addresses #59)
* tweak virtual grid color themes, especially for 40H/series
* simplify virtual grid drag logic
* improve virtual grid key margins and spacing
* delay sending a listener notification from serialosc until after the size message is received