### PR TITLE
Update build process to run in official Rack tool chain.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ plugin.so
 .vscode/ipch
 /Rack-SDK
 Rack-SDK*.zip
+/dep
+ragel*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ DEPS += $(ragel)
 $(ragel):
 	$(WGET) http://www.colm.net/files/ragel/ragel-6.10.tar.gz
 	cd dep && $(UNTAR) ../ragel-6.10.tar.gz
-	cd dep/ragel-6.10 && $(CONFIGURE)
+	# Temporarily override the cross-compilation build flags to build ragel on build host (since we don't want to cross-compile it).
+	cd dep/ragel-6.10 && CC=gcc CXX=g++ STRIP=strip FLAGS= CFLAGS= CXXFLAGS= LDFLAGS= ./configure --prefix="$(DEP_PATH)"
 	cd dep/ragel-6.10 && $(MAKE) && $(MAKE) install
 
 firmwares: export PATH := $(PWD)/dep/bin:$(PATH)

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,17 @@ else
 	SOURCES += $(wildcard lib/oscpack/ip/posix/*.cpp) 
 endif
 
+# Dependencies
+ragel := dep/bin/ragel
+DEPS += $(ragel)
+
+$(ragel):
+	$(WGET) http://www.colm.net/files/ragel/ragel-6.10.tar.gz
+	cd dep && $(UNTAR) ../ragel-6.10.tar.gz
+	cd dep/ragel-6.10 && $(CONFIGURE)
+	cd dep/ragel-6.10 && $(MAKE) && $(MAKE) install
+
+firmwares: export PATH := $(PWD)/dep/bin:$(PATH)
 firmwares: firmware/*.mk firmware/**/*.c firmware/**/*.h firmware/**/**/*.rl
 	cd firmware && $(MAKE) -f whitewhale.mk
 	cd firmware && $(MAKE) -f meadowphysics.mk


### PR DESCRIPTION
Build `ragel` as part of the `make dep` target for all platforms since the official Rack toolchain does not have it installed.