### PR TITLE
Feat/grid swapping

### DIFF
--- a/src/ansible/AnsibleModule.cpp
+++ b/src/ansible/AnsibleModule.cpp
@@ -17,6 +17,7 @@ AnsibleModule::AnsibleModule()
     configOutput(CV2_OUTPUT, "CV 2");
     configOutput(CV3_OUTPUT, "CV 3");
     configOutput(CV4_OUTPUT, "CV 4");
+    configButton(USB_PARAM, "USB");
 }
 
 void AnsibleModule::processInputs(const ProcessArgs& args)

--- a/src/ansible/AnsibleModule.cpp
+++ b/src/ansible/AnsibleModule.cpp
@@ -18,6 +18,8 @@ AnsibleModule::AnsibleModule()
     configOutput(CV3_OUTPUT, "CV 3");
     configOutput(CV4_OUTPUT, "CV 4");
     configButton(USB_PARAM, "USB Device Port");
+
+    setDeviceConnectionParam(USB_PARAM);
 }
 
 void AnsibleModule::processInputs(const ProcessArgs& args)

--- a/src/ansible/AnsibleModule.cpp
+++ b/src/ansible/AnsibleModule.cpp
@@ -17,7 +17,7 @@ AnsibleModule::AnsibleModule()
     configOutput(CV2_OUTPUT, "CV 2");
     configOutput(CV3_OUTPUT, "CV 3");
     configOutput(CV4_OUTPUT, "CV 4");
-    configButton(USB_PARAM, "USB");
+    configButton(USB_PARAM, "USB Device Port");
 }
 
 void AnsibleModule::processInputs(const ProcessArgs& args)

--- a/src/ansible/AnsibleModule.hpp
+++ b/src/ansible/AnsibleModule.hpp
@@ -9,6 +9,7 @@ struct AnsibleModule : LibAVR32Module
         KEY1_PARAM,
         KEY2_PARAM,
         MODE_PARAM,
+        USB_PARAM,
         NUM_PARAMS
     };
 

--- a/src/ansible/AnsibleWidget.cpp
+++ b/src/ansible/AnsibleWidget.cpp
@@ -65,7 +65,7 @@ AnsibleWidget::AnsibleWidget(AnsibleModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(10, 338), module, AnsibleModule::USB_PARAM);
+    auto usb = createParam<USBAJack>(Vec(7, 333), module, AnsibleModule::USB_PARAM);
     if (module && usb)
     {
         usb->action = [=]()

--- a/src/ansible/AnsibleWidget.cpp
+++ b/src/ansible/AnsibleWidget.cpp
@@ -65,16 +65,7 @@ AnsibleWidget::AnsibleWidget(AnsibleModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(7, 333), module, AnsibleModule::USB_PARAM);
-    if (module && usb)
-    {
-        usb->action = [=]()
-        {
-            module->reacquireGrid();
-        };
-        addChild(usb);
-    }
-
+    addParam(createParam<USBAJack>(Vec(7, 333), module, AnsibleModule::USB_PARAM));
     addParam(createParam<TL1105>(Vec(62, 336), module, AnsibleModule::MODE_PARAM));
     addParam(createParam<HoldableButton>(Vec(19, 256), module, AnsibleModule::KEY1_PARAM));
     addParam(createParam<HoldableButton>(Vec(54, 256), module, AnsibleModule::KEY2_PARAM));

--- a/src/ansible/AnsibleWidget.cpp
+++ b/src/ansible/AnsibleWidget.cpp
@@ -64,7 +64,16 @@ AnsibleWidget::AnsibleWidget(AnsibleModule* module)
 
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
-    addChild(createWidget<USBAJack>(Vec(10, 338)));
+
+    auto usb = createParam<USBAJack>(Vec(10, 338), module, AnsibleModule::USB_PARAM);
+    if (module && usb)
+    {
+        usb->action = [=]()
+        {
+            module->reacquireGrid();
+        };
+        addChild(usb);
+    }
 
     addParam(createParam<TL1105>(Vec(62, 336), module, AnsibleModule::MODE_PARAM));
     addParam(createParam<HoldableButton>(Vec(19, 256), module, AnsibleModule::KEY1_PARAM));

--- a/src/common/CommonWidgets.cpp
+++ b/src/common/CommonWidgets.cpp
@@ -5,7 +5,6 @@
 extern rack::Plugin* pluginInstance;
 
 USBAJack::USBAJack()
-: action(nullptr)
 {
     box.size = Vec(44, 23.75);
 }
@@ -19,7 +18,8 @@ void USBAJack::draw(const DrawArgs& args)
     float h = box.size.y;
     float z = 4.75;
 
-    if (m && m->connectionOwned && m->gridConnection)
+    engine::ParamQuantity* pq = getParamQuantity();
+    if (pq && pq->getValue() >= 1.0)
     {
         // draw shadow
         nvgBeginPath(vg);
@@ -40,13 +40,12 @@ void USBAJack::draw(const DrawArgs& args)
         nvgFill(vg);
 
         // draw embossed text label
-        auto id = m->gridConnection->getDevice().id;
-        std::string label = id.substr(0, 11);
+        std::string label = m->currentConnectedDeviceId.substr(0, 11);
         nvgFontSize(vg, 6.0);
         nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_BOTTOM);
         nvgFillColor(vg, nvgRGB(250, 250, 250));
         nvgText(vg, w - 4.1, z + 12.4, label.c_str(), 0);
-        nvgFillColor(vg, nvgRGB(160, 160, 160));
+        nvgFillColor(vg, nvgRGB(150, 150, 150));
         nvgText(vg, w - 4.5, z + 12, label.c_str(), 0);
     }
     else
@@ -79,19 +78,6 @@ void USBAJack::draw(const DrawArgs& args)
         nvgFillColor(vg, nvgRGB(120, 120, 120));
         nvgFill(vg);
     }
-}
-
-void USBAJack::onButton(const ButtonEvent& e)
-{
-    if (e.button == GLFW_MOUSE_BUTTON_LEFT)
-    {
-        if (action != nullptr)
-        {
-            action();
-        }
-    }
-
-    MomentarySwitch<Switch>::onButton(e);
 }
 
 void USBAJack::appendContextMenu(ui::Menu* menu)

--- a/src/common/CommonWidgets.cpp
+++ b/src/common/CommonWidgets.cpp
@@ -1,17 +1,75 @@
 #include "CommonWidgets.hpp"
+#include "LibAVR32Module.hpp"
 
 extern rack::Plugin* pluginInstance;
 
 void USBAJack::draw(const DrawArgs& args)
 {
     auto vg = args.vg;
-    nvgBeginPath(vg);
-    nvgRoundedRect(vg, 0, 0, 38, 14, 1.5);
-    nvgFillColor(vg, nvgRGB(0, 0, 0));
-    nvgFill(vg);
+    auto m = dynamic_cast<LibAVR32Module*>(module);
 
-    nvgBeginPath(vg);
-    nvgRect(vg, 4, 4, 30, 3);
-    nvgFillColor(vg, nvgRGB(120, 120, 120));
-    nvgFill(vg);
+    if (m && m->connectionOwned && m->gridConnection)
+    {
+        float height = 4.75;
+
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, -3, -1, 44, 20, 4.5);
+        nvgFillColor(vg, nvgRGB(165, 165, 165));
+        nvgFill(vg);
+
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, -3, -height, 44, 20, 3.5);
+        nvgFillColor(vg, nvgRGB(200, 200, 200));
+        nvgFill(vg);
+
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, -1, -height+1, 40, 18, 3);
+        nvgFillPaint(vg, nvgBoxGradient(vg, -1, -height+1, 40, 18, 2, 5, nvgRGB(225, 225, 225), nvgRGB(190, 190, 190)));
+        nvgFill(vg);
+
+        auto id = m->gridConnection->getDevice().id;
+        auto label = id.substr(0, 9);
+        nvgFontSize(vg, 6.0);
+        nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_BOTTOM);
+        nvgFillColor(vg, nvgRGB(250, 250, 250));
+        nvgText(vg, 36.2, 12.4, label.c_str(), 0);
+        nvgFillColor(vg, nvgRGB(170, 170, 170));
+        nvgText(vg, 35.8, 12, label.c_str(), 0);
+    }
+    else
+    {
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, 0, 0, 38, 14, 1.5);
+        nvgFillColor(vg, nvgRGB(0, 0, 0));
+        nvgFill(vg);
+
+        nvgBeginPath(vg);
+        nvgRect(vg, 4, 4, 30, 6);
+        nvgFillColor(vg, nvgRGB(50, 50, 50));
+        nvgFill(vg);
+
+        float p = 30 / 8.5;
+
+        nvgBeginPath(vg);
+        nvgRoundedRect(vg, 4 + 1 * p, 5, p, 4, 1.5);
+        nvgRoundedRect(vg, 4 + 2.9 * p, 5, p, 3.5, 1.5);
+        nvgRoundedRect(vg, 4 + 4.6 * p, 5, p, 3.5, 1.5);
+        nvgRoundedRect(vg, 4 + 6.5 * p, 5, p, 4, 1.5);
+        nvgFillColor(vg, nvgRGB(77, 75, 0));
+        nvgFill(vg);
+
+        nvgBeginPath(vg);
+        nvgRect(vg, 4, 4, 30, 3);
+        nvgFillColor(vg, nvgRGB(120, 120, 120));
+        nvgFill(vg);
+    }
+}
+
+void USBAJack::onButton(const ButtonEvent& e)
+{
+    MomentarySwitch<Switch>::onButton(e);
+    if (action != nullptr)
+    {
+        action();
+    }
 }

--- a/src/common/CommonWidgets.cpp
+++ b/src/common/CommonWidgets.cpp
@@ -1,65 +1,81 @@
 #include "CommonWidgets.hpp"
 #include "LibAVR32Module.hpp"
+#include "LibAVR32ModuleWidget.hpp"
 
 extern rack::Plugin* pluginInstance;
+
+USBAJack::USBAJack()
+: action(nullptr)
+{
+    box.size = Vec(44, 23.75);
+}
 
 void USBAJack::draw(const DrawArgs& args)
 {
     auto vg = args.vg;
     auto m = dynamic_cast<LibAVR32Module*>(module);
 
+    float w = box.size.x;
+    float h = box.size.y;
+    float z = 4.75;
+
     if (m && m->connectionOwned && m->gridConnection)
     {
-        float height = 4.75;
-
+        // draw shadow
         nvgBeginPath(vg);
-        nvgRoundedRect(vg, -3, -1, 44, 20, 4.5);
+        nvgRoundedRect(vg, 0, z - 1, w, h - z + 1, 4.5);
         nvgFillColor(vg, nvgRGB(165, 165, 165));
         nvgFill(vg);
 
+        // draw face
         nvgBeginPath(vg);
-        nvgRoundedRect(vg, -3, -height, 44, 20, 3.5);
+        nvgRoundedRect(vg, 0, 0, w, h - z + 1, 3.5);
         nvgFillColor(vg, nvgRGB(200, 200, 200));
         nvgFill(vg);
 
+        // draw 3D highlight
         nvgBeginPath(vg);
-        nvgRoundedRect(vg, -1, -height+1, 40, 18, 3);
-        nvgFillPaint(vg, nvgBoxGradient(vg, -1, -height+1, 40, 18, 2, 5, nvgRGB(225, 225, 225), nvgRGB(190, 190, 190)));
+        nvgRoundedRect(vg, 2, 1, w - 4, h - z - 1, 3);
+        nvgFillPaint(vg, nvgBoxGradient(vg, 2, 1, w - 4, 18, 2, 5, nvgRGB(225, 225, 225), nvgRGB(190, 190, 190)));
         nvgFill(vg);
 
+        // draw embossed text label
         auto id = m->gridConnection->getDevice().id;
-        auto label = id.substr(0, 9);
+        std::string label = id.substr(0, 11);
         nvgFontSize(vg, 6.0);
         nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_BOTTOM);
         nvgFillColor(vg, nvgRGB(250, 250, 250));
-        nvgText(vg, 36.2, 12.4, label.c_str(), 0);
-        nvgFillColor(vg, nvgRGB(170, 170, 170));
-        nvgText(vg, 35.8, 12, label.c_str(), 0);
+        nvgText(vg, w - 4.1, z + 12.4, label.c_str(), 0);
+        nvgFillColor(vg, nvgRGB(160, 160, 160));
+        nvgText(vg, w - 4.5, z + 12, label.c_str(), 0);
     }
     else
     {
+        // draw port background
         nvgBeginPath(vg);
-        nvgRoundedRect(vg, 0, 0, 38, 14, 1.5);
+        nvgRoundedRect(vg, 3, z, w - 6, h - z - 5, 1.5);
         nvgFillColor(vg, nvgRGB(0, 0, 0));
         nvgFill(vg);
 
+        // draw connector base
         nvgBeginPath(vg);
-        nvgRect(vg, 4, 4, 30, 6);
+        nvgRect(vg, 7, 4 + z, w - 14, 6);
         nvgFillColor(vg, nvgRGB(50, 50, 50));
         nvgFill(vg);
 
-        float p = 30 / 8.5;
-
+        // draw contacts
+        float p = (w - 14) / 8.5;
         nvgBeginPath(vg);
-        nvgRoundedRect(vg, 4 + 1 * p, 5, p, 4, 1.5);
-        nvgRoundedRect(vg, 4 + 2.9 * p, 5, p, 3.5, 1.5);
-        nvgRoundedRect(vg, 4 + 4.6 * p, 5, p, 3.5, 1.5);
-        nvgRoundedRect(vg, 4 + 6.5 * p, 5, p, 4, 1.5);
+        nvgRoundedRect(vg, 7 + 1 * p, z + 5, p, 4, 1.5);
+        nvgRoundedRect(vg, 7 + 2.9 * p, z + 5, p, 3.5, 1.5);
+        nvgRoundedRect(vg, 7 + 4.6 * p, z + 5, p, 3.5, 1.5);
+        nvgRoundedRect(vg, 7 + 6.5 * p, z + 5, p, 4, 1.5);
         nvgFillColor(vg, nvgRGB(77, 75, 0));
         nvgFill(vg);
 
+        // draw connector prong
         nvgBeginPath(vg);
-        nvgRect(vg, 4, 4, 30, 3);
+        nvgRect(vg, 7, 4 + z, 30, 3);
         nvgFillColor(vg, nvgRGB(120, 120, 120));
         nvgFill(vg);
     }
@@ -67,9 +83,23 @@ void USBAJack::draw(const DrawArgs& args)
 
 void USBAJack::onButton(const ButtonEvent& e)
 {
-    MomentarySwitch<Switch>::onButton(e);
-    if (action != nullptr)
+    if (e.button == GLFW_MOUSE_BUTTON_LEFT)
     {
-        action();
+        if (action != nullptr)
+        {
+            action();
+        }
+    }
+
+    MomentarySwitch<Switch>::onButton(e);
+}
+
+void USBAJack::appendContextMenu(ui::Menu* menu)
+{
+    LibAVR32ModuleWidget* mw = dynamic_cast<LibAVR32ModuleWidget*>(parent);
+    if (mw)
+    {
+        menu->addChild(new MenuSeparator());
+        mw->appendConnectionMenu(menu);
     }
 }

--- a/src/common/CommonWidgets.hpp
+++ b/src/common/CommonWidgets.hpp
@@ -6,11 +6,11 @@ using namespace rack;
 
 struct USBAJack : MomentarySwitch<Switch>
 {
-    USBAJack()
-        : action(nullptr) {};
+    USBAJack();
 
     void draw(const DrawArgs& args) override;
     void onButton(const ButtonEvent& e) override;
+    void appendContextMenu(ui::Menu* menu) override;
 
     std::function<void(void)> action;
 };

--- a/src/common/CommonWidgets.hpp
+++ b/src/common/CommonWidgets.hpp
@@ -4,9 +4,15 @@
 
 using namespace rack;
 
-struct USBAJack : TransparentWidget
+struct USBAJack : MomentarySwitch<Switch>
 {
+    USBAJack()
+        : action(nullptr) {};
+
     void draw(const DrawArgs& args) override;
+    void onButton(const ButtonEvent& e) override;
+
+    std::function<void(void)> action;
 };
 
 struct YellowWhiteLight : rack::componentlibrary::GrayModuleLightWidget

--- a/src/common/CommonWidgets.hpp
+++ b/src/common/CommonWidgets.hpp
@@ -4,15 +4,12 @@
 
 using namespace rack;
 
-struct USBAJack : MomentarySwitch<Switch>
+struct USBAJack : Switch
 {
     USBAJack();
 
     void draw(const DrawArgs& args) override;
-    void onButton(const ButtonEvent& e) override;
     void appendContextMenu(ui::Menu* menu) override;
-
-    std::function<void(void)> action;
 };
 
 struct YellowWhiteLight : rack::componentlibrary::GrayModuleLightWidget

--- a/src/common/GridConnection/GridConnection.cpp
+++ b/src/common/GridConnection/GridConnection.cpp
@@ -12,7 +12,7 @@ void GridConnectionManager::registerGrid(Grid* grid)
     GridConsumer* consumerToConnect = nullptr;
     for (auto consumer : consumers)
     {
-        if (!isConnected(consumer) && grid->getDevice().id == consumer->gridGetLastDeviceId())
+        if (!isConnected(consumer) && grid->getDevice().id == consumer->gridGetLastDeviceId(true))
         {
             consumerToConnect = consumer;
             break;
@@ -33,7 +33,7 @@ void GridConnectionManager::registerGridConsumer(GridConsumer* consumer)
     Grid* gridToConnect = nullptr;
     for (auto grid : grids)
     {
-        if (!isConnected(grid->getDevice().id) && consumer->gridGetLastDeviceId() == grid->getDevice().id)
+        if (!isConnected(grid->getDevice().id) && consumer->gridGetLastDeviceId(true) == grid->getDevice().id)
         {
             gridToConnect = grid;
             break;

--- a/src/common/GridConnection/GridConnection.hpp
+++ b/src/common/GridConnection/GridConnection.hpp
@@ -21,7 +21,7 @@ struct GridConsumer
 {
     virtual void gridConnected(Grid* grid) = 0;
     virtual void gridDisconnected(bool ownerChanged) = 0;
-    virtual std::string gridGetLastDeviceId() = 0;
+    virtual std::string gridGetLastDeviceId(bool owned) = 0;
     virtual void gridButtonEvent(int x, int y, bool state) = 0;
     virtual void encDeltaEvent(int n, int d) = 0;
 };

--- a/src/common/LibAVR32Module.cpp
+++ b/src/common/LibAVR32Module.cpp
@@ -138,6 +138,21 @@ std::string LibAVR32Module::gridGetLastDeviceId(bool owned)
     return lastConnectedDeviceId;
 }
 
+void LibAVR32Module::reacquireGrid()
+{
+    if (lastConnectedDeviceId != "" && gridConnection == nullptr)
+    {
+        for (Grid* grid : GridConnectionManager::get().getGrids())
+        {
+            if (gridGetLastDeviceId(false) == grid->getDevice().id)
+            {
+                GridConnectionManager::get().connect(grid, this);
+                return;
+            }
+        }
+    }
+}
+
 void LibAVR32Module::readSerialMessages()
 {
     uint8_t* msg;

--- a/src/common/LibAVR32Module.cpp
+++ b/src/common/LibAVR32Module.cpp
@@ -22,7 +22,6 @@ LibAVR32Module::LibAVR32Module(std::string firmwareName)
     firmware.advanceClock(0.02);
     firmware.step();
 
-    GridConnectionManager::get().registerGridConsumer(this);
 }
 
 LibAVR32Module::~LibAVR32Module()
@@ -405,6 +404,8 @@ void LibAVR32Module::dataFromJson(json_t* rootJ)
             outputRate = value;
         }
     }
+
+    GridConnectionManager::get().registerGridConsumer(this);
 }
 
 void LibAVR32Module::onReset() {

--- a/src/common/LibAVR32Module.hpp
+++ b/src/common/LibAVR32Module.hpp
@@ -60,7 +60,8 @@ struct LibAVR32Module : rack::engine::Module, GridConsumer
     void encDeltaEvent(int n, int d) override;
     std::string gridGetLastDeviceId(bool owned) override;
 
-    void reacquireGrid();
+    void userReacquireGrid();
+    void userToggleGridConnection(Grid* grid);
 
     virtual void readSerialMessages();
     void requestReloadFirmware(ReloadRequest request) { reloadRequested = request; }
@@ -68,8 +69,8 @@ struct LibAVR32Module : rack::engine::Module, GridConsumer
     float dacToVolts(uint16_t adc);
     uint16_t voltsToAdc(float volts);
 
-    Grid* gridConnection;
     std::string lastConnectedDeviceId;
+    std::string currentConnectedDeviceId;
     bool connectionOwned;
 
     std::string firmwareName;
@@ -84,6 +85,11 @@ struct LibAVR32Module : rack::engine::Module, GridConsumer
 
 protected:
     void reloadFirmware(bool preserveMemory);
+
+    Grid* gridConnection;
+    int usbParamId;
+    void setDeviceConnectionParam(int paramId) { usbParamId = paramId; }
+    void processDeviceConnectionParam();
 
     ReloadRequest reloadRequested;
 

--- a/src/common/LibAVR32Module.hpp
+++ b/src/common/LibAVR32Module.hpp
@@ -60,6 +60,8 @@ struct LibAVR32Module : rack::engine::Module, GridConsumer
     void encDeltaEvent(int n, int d) override;
     std::string gridGetLastDeviceId(bool owned) override;
 
+    void reacquireGrid();
+
     virtual void readSerialMessages();
     void requestReloadFirmware(ReloadRequest request) { reloadRequested = request; }
 

--- a/src/common/LibAVR32Module.hpp
+++ b/src/common/LibAVR32Module.hpp
@@ -58,7 +58,7 @@ struct LibAVR32Module : rack::engine::Module, GridConsumer
     void gridDisconnected(bool ownerChanged) override;
     void gridButtonEvent(int x, int y, bool state) override;
     void encDeltaEvent(int n, int d) override;
-    std::string gridGetLastDeviceId() override;
+    std::string gridGetLastDeviceId(bool owned) override;
 
     virtual void readSerialMessages();
     void requestReloadFirmware(ReloadRequest request) { reloadRequested = request; }
@@ -68,6 +68,8 @@ struct LibAVR32Module : rack::engine::Module, GridConsumer
 
     Grid* gridConnection;
     std::string lastConnectedDeviceId;
+    bool connectionOwned;
+
     std::string firmwareName;
 
     int inputRate;

--- a/src/common/LibAVR32ModuleWidget.cpp
+++ b/src/common/LibAVR32ModuleWidget.cpp
@@ -105,26 +105,6 @@ struct FirmwareSubmenuItem : MenuItem
     }
 };
 
-void LibAVR32ModuleWidget::reacquireGrid()
-{
-    LibAVR32Module* m = dynamic_cast<LibAVR32Module*>(module);
-    if (!m) {
-        return;
-    }
-
-    if (m->lastConnectedDeviceId != "" && m->gridConnection == nullptr)
-    {
-        for (Grid* grid : GridConnectionManager::get().getGrids())
-        {
-            if (m->gridGetLastDeviceId(false) == grid->getDevice().id)
-            {
-                GridConnectionManager::get().connect(grid, m);
-                return;
-            }
-        }
-    }
-}
-
 LibAVR32ModuleWidget::LibAVR32ModuleWidget()
 {
 }
@@ -191,8 +171,8 @@ void LibAVR32ModuleWidget::appendContextMenu(rack::Menu* menu)
 
     if (m->gridConnection == nullptr && m->gridGetLastDeviceId(false) != "")
     {
-        menu->addChild(createMenuItem("Reacquire grid", "", [this]()
-            { this->reacquireGrid(); }
+        menu->addChild(createMenuItem("Reacquire grid", "", [=]()
+            { m->reacquireGrid(); }
         ));
     }
 }

--- a/src/common/LibAVR32ModuleWidget.cpp
+++ b/src/common/LibAVR32ModuleWidget.cpp
@@ -16,6 +16,7 @@ struct ConnectGridItem : rack::ui::MenuItem
         if (module && module->gridConnection == grid)
         {
             GridConnectionManager::get().disconnect(module, true);
+            module->lastConnectedDeviceId = "";
         }
         else
         {
@@ -123,6 +124,14 @@ void LibAVR32ModuleWidget::appendContextMenu(rack::Menu* menu)
     menu->addChild(firmwareMenu);
 
     menu->addChild(new MenuSeparator());
+    appendConnectionMenu(menu);
+}
+
+void LibAVR32ModuleWidget::appendConnectionMenu(rack::Menu* menu)
+{
+    LibAVR32Module* m = dynamic_cast<LibAVR32Module*>(module);
+    assert(m);
+
     menu->addChild(construct<MenuLabel>(&MenuLabel::text, "Device Connection"));
 
     if (SerialOscInterface::get()->isServiceDetected())
@@ -130,8 +139,10 @@ void LibAVR32ModuleWidget::appendContextMenu(rack::Menu* menu)
         menu->addChild(
             construct<MenuLabel>(
                 &MenuLabel::text,
-                "└ serialosc version " + SerialOscInterface::get()->getServiceVersion()));
-    } else {
+                "serialosc version " + SerialOscInterface::get()->getServiceVersion()));
+    }
+    else
+    {
         menu->addChild(
             createMenuItem("└ serialosc service not detected, click here to install", "",
                 [=]()
@@ -145,9 +156,10 @@ void LibAVR32ModuleWidget::appendContextMenu(rack::Menu* menu)
     for (Grid* grid : GridConnectionManager::get().getGrids())
     {
         auto connectItem = new ConnectGridItem();
-        connectItem->text = grid->getDevice().type + " (" + grid->getDevice().id + ")";
+        connectItem->text = "└ " + grid->getDevice().type + "(" + grid->getDevice().id + ") ";
 
-        auto rightText = "";
+            auto rightText
+            = "";
         if (m->gridConnection && m->gridConnection->getDevice().id == grid->getDevice().id)
         {
             rightText = "✔";
@@ -166,13 +178,12 @@ void LibAVR32ModuleWidget::appendContextMenu(rack::Menu* menu)
 
     if (deviceCount == 0)
     {
-        menu->addChild(construct<MenuLabel>(&MenuLabel::text, "(no physical or virtual devices found)"));
+        menu->addChild(construct<MenuLabel>(&MenuLabel::text, "  (no physical or virtual devices found)"));
     }
 
     if (m->gridConnection == nullptr && m->gridGetLastDeviceId(false) != "")
     {
         menu->addChild(createMenuItem("Reacquire grid", "", [=]()
-            { m->reacquireGrid(); }
-        ));
+            { m->reacquireGrid(); }));
     }
 }

--- a/src/common/LibAVR32ModuleWidget.hpp
+++ b/src/common/LibAVR32ModuleWidget.hpp
@@ -10,4 +10,5 @@ struct LibAVR32ModuleWidget : rack::app::ModuleWidget
     LibAVR32ModuleWidget();
 
     virtual void appendContextMenu(rack::ui::Menu* menu) override;
+    void appendConnectionMenu(rack::Menu* menu);
 };

--- a/src/common/LibAVR32ModuleWidget.hpp
+++ b/src/common/LibAVR32ModuleWidget.hpp
@@ -9,5 +9,7 @@ struct LibAVR32ModuleWidget : rack::app::ModuleWidget
 {
     LibAVR32ModuleWidget();
 
+    void reacquireGrid();
+
     virtual void appendContextMenu(rack::ui::Menu* menu) override;
 };

--- a/src/common/LibAVR32ModuleWidget.hpp
+++ b/src/common/LibAVR32ModuleWidget.hpp
@@ -9,7 +9,5 @@ struct LibAVR32ModuleWidget : rack::app::ModuleWidget
 {
     LibAVR32ModuleWidget();
 
-    void reacquireGrid();
-
     virtual void appendContextMenu(rack::ui::Menu* menu) override;
 };

--- a/src/earthsea/EarthseaModule.cpp
+++ b/src/earthsea/EarthseaModule.cpp
@@ -15,7 +15,7 @@ EarthseaModule::EarthseaModule()
     configOutput(CV3_OUTPUT, "SHAPE 3");
     configOutput(EDGE_OUTPUT, "EDGE");
     configOutput(POS_OUTPUT, "POS");
-    configButton(USB_PARAM, "USB");
+    configButton(USB_PARAM, "USB Device Port");
 }
 
 void EarthseaModule::processInputs(const ProcessArgs& args)

--- a/src/earthsea/EarthseaModule.cpp
+++ b/src/earthsea/EarthseaModule.cpp
@@ -15,6 +15,7 @@ EarthseaModule::EarthseaModule()
     configOutput(CV3_OUTPUT, "SHAPE 3");
     configOutput(EDGE_OUTPUT, "EDGE");
     configOutput(POS_OUTPUT, "POS");
+    configButton(USB_PARAM, "USB");
 }
 
 void EarthseaModule::processInputs(const ProcessArgs& args)

--- a/src/earthsea/EarthseaModule.cpp
+++ b/src/earthsea/EarthseaModule.cpp
@@ -16,6 +16,8 @@ EarthseaModule::EarthseaModule()
     configOutput(EDGE_OUTPUT, "EDGE");
     configOutput(POS_OUTPUT, "POS");
     configButton(USB_PARAM, "USB Device Port");
+
+    setDeviceConnectionParam(USB_PARAM);
 }
 
 void EarthseaModule::processInputs(const ProcessArgs& args)

--- a/src/earthsea/EarthseaModule.hpp
+++ b/src/earthsea/EarthseaModule.hpp
@@ -10,6 +10,7 @@ struct EarthseaModule : LibAVR32Module
         CV2_PARAM,
         CV3_PARAM,
         BUTTON_PARAM,
+        USB_PARAM,
         NUM_PARAMS
     };
 

--- a/src/earthsea/EarthseaWidget.cpp
+++ b/src/earthsea/EarthseaWidget.cpp
@@ -22,16 +22,7 @@ EarthseaWidget::EarthseaWidget(EarthseaModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(7, 333), module, EarthseaModule::USB_PARAM);
-    if (module && usb)
-    {
-        usb->action = [=]()
-        {
-            module->reacquireGrid();
-        };
-        addChild(usb);
-    }
-
+    addParam(createParam<USBAJack>(Vec(7, 333), module, EarthseaModule::USB_PARAM));
     addParam(createParam<TL1105>(Vec(62, 336), module, EarthseaModule::BUTTON_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12.5, 30), module, EarthseaModule::CV1_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12.5, 116), module, EarthseaModule::CV2_PARAM));

--- a/src/earthsea/EarthseaWidget.cpp
+++ b/src/earthsea/EarthseaWidget.cpp
@@ -21,7 +21,16 @@ EarthseaWidget::EarthseaWidget(EarthseaModule* module)
     // Screws positioned for sliding nuts :)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
-    addChild(createWidget<USBAJack>(Vec(10, 338)));
+
+    auto usb = createParam<USBAJack>(Vec(10, 338), module, EarthseaModule::USB_PARAM);
+    if (module && usb)
+    {
+        usb->action = [=]()
+        {
+            module->reacquireGrid();
+        };
+        addChild(usb);
+    }
 
     addParam(createParam<TL1105>(Vec(62, 336), module, EarthseaModule::BUTTON_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12.5, 30), module, EarthseaModule::CV1_PARAM));

--- a/src/earthsea/EarthseaWidget.cpp
+++ b/src/earthsea/EarthseaWidget.cpp
@@ -22,7 +22,7 @@ EarthseaWidget::EarthseaWidget(EarthseaModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(10, 338), module, EarthseaModule::USB_PARAM);
+    auto usb = createParam<USBAJack>(Vec(7, 333), module, EarthseaModule::USB_PARAM);
     if (module && usb)
     {
         usb->action = [=]()

--- a/src/meadowphysics/MeadowphysicsModule.cpp
+++ b/src/meadowphysics/MeadowphysicsModule.cpp
@@ -18,6 +18,8 @@ MeadowphysicsModule::MeadowphysicsModule()
     configOutput(TR7_OUTPUT, "TR 7");
     configOutput(TR8_OUTPUT, "TR 8");
     configButton(USB_PARAM, "USB Device Port");
+
+    setDeviceConnectionParam(USB_PARAM);
 }
 
 void MeadowphysicsModule::processInputs(const ProcessArgs& args)

--- a/src/meadowphysics/MeadowphysicsModule.cpp
+++ b/src/meadowphysics/MeadowphysicsModule.cpp
@@ -17,6 +17,7 @@ MeadowphysicsModule::MeadowphysicsModule()
     configOutput(TR6_OUTPUT, "TR 6");
     configOutput(TR7_OUTPUT, "TR 7");
     configOutput(TR8_OUTPUT, "TR 8");
+    configButton(USB_PARAM, "USB");
 }
 
 void MeadowphysicsModule::processInputs(const ProcessArgs& args)

--- a/src/meadowphysics/MeadowphysicsModule.cpp
+++ b/src/meadowphysics/MeadowphysicsModule.cpp
@@ -17,7 +17,7 @@ MeadowphysicsModule::MeadowphysicsModule()
     configOutput(TR6_OUTPUT, "TR 6");
     configOutput(TR7_OUTPUT, "TR 7");
     configOutput(TR8_OUTPUT, "TR 8");
-    configButton(USB_PARAM, "USB");
+    configButton(USB_PARAM, "USB Device Port");
 }
 
 void MeadowphysicsModule::processInputs(const ProcessArgs& args)

--- a/src/meadowphysics/MeadowphysicsModule.hpp
+++ b/src/meadowphysics/MeadowphysicsModule.hpp
@@ -8,6 +8,7 @@ struct MeadowphysicsModule : LibAVR32Module
     {
         CLOCK_PARAM,
         BUTTON_PARAM,
+        USB_PARAM,
         NUM_PARAMS
     };
 

--- a/src/meadowphysics/MeadowphysicsWidget.cpp
+++ b/src/meadowphysics/MeadowphysicsWidget.cpp
@@ -21,7 +21,16 @@ MeadowphysicsWidget::MeadowphysicsWidget(MeadowphysicsModule* module)
     // Screws positioned for sliding nuts :)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
-    addChild(createWidget<USBAJack>(Vec(10, 338)));
+
+    auto usb = createParam<USBAJack>(Vec(10, 338), module, MeadowphysicsModule::USB_PARAM);
+    if (module && usb)
+    {
+        usb->action = [=]()
+        {
+            module->reacquireGrid();
+        };
+        addChild(usb);
+    }
 
     addParam(createParam<TL1105>(Vec(62, 336), module, MeadowphysicsModule::BUTTON_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12, 232), module, MeadowphysicsModule::CLOCK_PARAM));

--- a/src/meadowphysics/MeadowphysicsWidget.cpp
+++ b/src/meadowphysics/MeadowphysicsWidget.cpp
@@ -22,7 +22,7 @@ MeadowphysicsWidget::MeadowphysicsWidget(MeadowphysicsModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(10, 338), module, MeadowphysicsModule::USB_PARAM);
+    auto usb = createParam<USBAJack>(Vec(7, 333), module, MeadowphysicsModule::USB_PARAM);
     if (module && usb)
     {
         usb->action = [=]()

--- a/src/meadowphysics/MeadowphysicsWidget.cpp
+++ b/src/meadowphysics/MeadowphysicsWidget.cpp
@@ -22,16 +22,7 @@ MeadowphysicsWidget::MeadowphysicsWidget(MeadowphysicsModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(7, 333), module, MeadowphysicsModule::USB_PARAM);
-    if (module && usb)
-    {
-        usb->action = [=]()
-        {
-            module->reacquireGrid();
-        };
-        addChild(usb);
-    }
-
+    addParam(createParam<USBAJack>(Vec(7, 333), module, MeadowphysicsModule::USB_PARAM));
     addParam(createParam<TL1105>(Vec(62, 336), module, MeadowphysicsModule::BUTTON_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12, 232), module, MeadowphysicsModule::CLOCK_PARAM));
 

--- a/src/teletype/TeletypeModule.cpp
+++ b/src/teletype/TeletypeModule.cpp
@@ -56,7 +56,9 @@ TeletypeModule::TeletypeModule()
     configOutput(CV2_OUTPUT, "CV 2");
     configOutput(CV3_OUTPUT, "CV 3");
     configOutput(CV4_OUTPUT, "CV 4");
-    configButton(USB_PARAM, "USB");
+    configButton(USB_PARAM, "USB Device Port");
+
+    setDeviceConnectionParam(USB_PARAM);
 }
 
 void TeletypeModule::processInputs(const ProcessArgs& args)

--- a/src/teletype/TeletypeModule.cpp
+++ b/src/teletype/TeletypeModule.cpp
@@ -56,6 +56,7 @@ TeletypeModule::TeletypeModule()
     configOutput(CV2_OUTPUT, "CV 2");
     configOutput(CV3_OUTPUT, "CV 3");
     configOutput(CV4_OUTPUT, "CV 4");
+    configButton(USB_PARAM, "USB");
 }
 
 void TeletypeModule::processInputs(const ProcessArgs& args)

--- a/src/teletype/TeletypeModule.hpp
+++ b/src/teletype/TeletypeModule.hpp
@@ -10,6 +10,7 @@ struct TeletypeModule : LibAVR32Module
     {
         PARAM_PARAM,
         BUTTON_PARAM,
+        USB_PARAM,
         NUM_PARAMS
     };
     enum InputIds

--- a/src/teletype/TeletypeWidget.cpp
+++ b/src/teletype/TeletypeWidget.cpp
@@ -28,16 +28,7 @@ TeletypeWidget::TeletypeWidget(TeletypeModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
     addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(7, 333), module, TeletypeModule::USB_PARAM);
-    if (module && usb)
-    {
-        usb->action = [=]()
-        {
-            module->reacquireGrid();
-        };
-        addChild(usb);
-    }
-
+    addParam(createParam<USBAJack>(Vec(7, 333), module, TeletypeModule::USB_PARAM));
     addParam(createParam<TL1105>(Vec(62, 337), module, TeletypeModule::BUTTON_PARAM));
 
     // addChild(createScrew<ScrewSilver>(Vec(11, 312)));

--- a/src/teletype/TeletypeWidget.cpp
+++ b/src/teletype/TeletypeWidget.cpp
@@ -28,7 +28,7 @@ TeletypeWidget::TeletypeWidget(TeletypeModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
     addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(10, 338), module, TeletypeModule::USB_PARAM);
+    auto usb = createParam<USBAJack>(Vec(7, 333), module, TeletypeModule::USB_PARAM);
     if (module && usb)
     {
         usb->action = [=]()

--- a/src/teletype/TeletypeWidget.cpp
+++ b/src/teletype/TeletypeWidget.cpp
@@ -28,7 +28,16 @@ TeletypeWidget::TeletypeWidget(TeletypeModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
     addChild(createWidget<ScrewSilver>(Vec(box.size.x - 2 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    addChild(createWidget<USBAJack>(Vec(10, 337)));
+    auto usb = createParam<USBAJack>(Vec(10, 338), module, TeletypeModule::USB_PARAM);
+    if (module && usb)
+    {
+        usb->action = [=]()
+        {
+            module->reacquireGrid();
+        };
+        addChild(usb);
+    }
+
     addParam(createParam<TL1105>(Vec(62, 337), module, TeletypeModule::BUTTON_PARAM));
 
     // addChild(createScrew<ScrewSilver>(Vec(11, 312)));

--- a/src/whitewhale/WhiteWhaleModule.cpp
+++ b/src/whitewhale/WhiteWhaleModule.cpp
@@ -16,6 +16,7 @@ WhiteWhaleModule::WhiteWhaleModule()
     configOutput(TR4_OUTPUT, "TR 4");
     configOutput(CVA_OUTPUT, "CV A");
     configOutput(CVB_OUTPUT, "CV B");
+    configButton(USB_PARAM, "USB");
 }
 
 void WhiteWhaleModule::processInputs(const ProcessArgs& args)

--- a/src/whitewhale/WhiteWhaleModule.cpp
+++ b/src/whitewhale/WhiteWhaleModule.cpp
@@ -16,7 +16,7 @@ WhiteWhaleModule::WhiteWhaleModule()
     configOutput(TR4_OUTPUT, "TR 4");
     configOutput(CVA_OUTPUT, "CV A");
     configOutput(CVB_OUTPUT, "CV B");
-    configButton(USB_PARAM, "USB");
+    configButton(USB_PARAM, "USB Device Port");
 }
 
 void WhiteWhaleModule::processInputs(const ProcessArgs& args)

--- a/src/whitewhale/WhiteWhaleModule.cpp
+++ b/src/whitewhale/WhiteWhaleModule.cpp
@@ -17,6 +17,8 @@ WhiteWhaleModule::WhiteWhaleModule()
     configOutput(CVA_OUTPUT, "CV A");
     configOutput(CVB_OUTPUT, "CV B");
     configButton(USB_PARAM, "USB Device Port");
+
+    setDeviceConnectionParam(USB_PARAM);
 }
 
 void WhiteWhaleModule::processInputs(const ProcessArgs& args)

--- a/src/whitewhale/WhiteWhaleModule.hpp
+++ b/src/whitewhale/WhiteWhaleModule.hpp
@@ -9,6 +9,7 @@ struct WhiteWhaleModule : LibAVR32Module
         CLOCK_PARAM,
         PARAM_PARAM,
         BUTTON_PARAM,
+        USB_PARAM,
         NUM_PARAMS
     };
 

--- a/src/whitewhale/WhiteWhaleWidget.cpp
+++ b/src/whitewhale/WhiteWhaleWidget.cpp
@@ -22,16 +22,7 @@ WhiteWhaleWidget::WhiteWhaleWidget(WhiteWhaleModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(7, 333), module, WhiteWhaleModule::USB_PARAM);
-    if (module && usb)
-    {
-        usb->action = [=]()
-        {
-            module->reacquireGrid();
-        };
-        addChild(usb);
-    }
-
+    addParam(createParam<USBAJack>(Vec(7, 333), module, WhiteWhaleModule::USB_PARAM));
     addParam(createParam<TL1105>(Vec(62, 336), module, WhiteWhaleModule::BUTTON_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12, 30), module, WhiteWhaleModule::PARAM_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12, 232), module, WhiteWhaleModule::CLOCK_PARAM));

--- a/src/whitewhale/WhiteWhaleWidget.cpp
+++ b/src/whitewhale/WhiteWhaleWidget.cpp
@@ -22,7 +22,7 @@ WhiteWhaleWidget::WhiteWhaleWidget(WhiteWhaleModule* module)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
-    auto usb = createParam<USBAJack>(Vec(10, 338), module, WhiteWhaleModule::USB_PARAM);
+    auto usb = createParam<USBAJack>(Vec(7, 333), module, WhiteWhaleModule::USB_PARAM);
     if (module && usb)
     {
         usb->action = [=]()

--- a/src/whitewhale/WhiteWhaleWidget.cpp
+++ b/src/whitewhale/WhiteWhaleWidget.cpp
@@ -21,7 +21,16 @@ WhiteWhaleWidget::WhiteWhaleWidget(WhiteWhaleModule* module)
     // Screws positioned for sliding nuts :)
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, 0)));
     addChild(createWidget<ScrewSilver>(Vec(RACK_GRID_WIDTH / 2, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
-    addChild(createWidget<USBAJack>(Vec(10, 338)));
+
+    auto usb = createParam<USBAJack>(Vec(10, 338), module, WhiteWhaleModule::USB_PARAM);
+    if (module && usb)
+    {
+        usb->action = [=]()
+        {
+            module->reacquireGrid();
+        };
+        addChild(usb);
+    }
 
     addParam(createParam<TL1105>(Vec(62, 336), module, WhiteWhaleModule::BUTTON_PARAM));
     addParam(createParam<SifamTPN111GrayBlackStripe>(Vec(12, 30), module, WhiteWhaleModule::PARAM_PARAM));


### PR DESCRIPTION
- New graphics for USB port; plugged/unplugged state to show connection to a grid device (physical or virtual)
- Click the USB port to reacquire the last assigned grid (disconnecting it from any other module)
- Make USB port mappable with VCV MIDI Map or Stoermelder MIDI-CAT 
- Revamp connection menu
- Make grid connection protected and managed by audio thread

Addresses #124.