### PR TITLE
Limit firmware .so/.dylib visibility to the public API; hide internal symbols

### DIFF
--- a/firmware/common.mk
+++ b/firmware/common.mk
@@ -8,6 +8,7 @@ FLAGS += \
 	-DNULL=0 \
 	-DARCH_AVR32=1 \
 	-fPIC \
+	-fvisibility=hidden \
 	-g \
 	-Werror=implicit-function-declaration \
 	-I../lib/cbbq \

--- a/firmware/mock_hardware/mock_hardware_api.h
+++ b/firmware/mock_hardware/mock_hardware_api.h
@@ -5,7 +5,16 @@
 #endif
 
 #ifndef MOCK_API
-#define MOCK_API(returntype, name, argslist) returntype hardware_##name argslist
+#ifdef ARCH_WIN
+#define MOCK_API(returntype, name, argslist) __declspec(dllexport) \
+returntype hardware_##name argslist
+#elif ARCH_MAC
+#define MOCK_API(returntype, name, argslist) \
+returntype hardware_##name argslist
+#elif ARCH_LIN
+#define MOCK_API(returntype, name, argslist) __attribute__((visibility("default"))) \
+returntype hardware_##name argslist
+#endif
 #endif
 
 MOCK_API(void, init, ());

--- a/firmware/mock_hardware/mock_hardware_api.h
+++ b/firmware/mock_hardware/mock_hardware_api.h
@@ -9,7 +9,7 @@
 #define MOCK_API(returntype, name, argslist) __declspec(dllexport) \
 returntype hardware_##name argslist
 #elif ARCH_MAC
-#define MOCK_API(returntype, name, argslist) \
+#define MOCK_API(returntype, name, argslist) __attribute__((visibility("default"))) \
 returntype hardware_##name argslist
 #elif ARCH_LIN
 #define MOCK_API(returntype, name, argslist) __attribute__((visibility("default"))) \


### PR DESCRIPTION
Fixes #129 (and is a more comprehensive fix to #78)