### PR TITLE
Grid mirroring followups

### DIFF
--- a/src/common/core/GridConnection/GridConnection.cpp
+++ b/src/common/core/GridConnection/GridConnection.cpp
@@ -123,6 +123,19 @@ void GridConnectionManager::disconnect(IGridConsumer* consumer, bool ownerChange
     }
 }
 
+void GridConnectionManager::toggleConnection(Grid* grid, IGridConsumer* consumer)
+{
+    if (consumer && consumer->gridGetDevice() == grid)
+    {
+        disconnect(consumer, true);
+        consumer->setLastDeviceId("");
+    }
+    else
+    {
+        connect(grid, consumer);
+    }
+}
+
 void GridConnectionManager::dispatchButtonMessage(MonomeDevice* device, int x, int y, bool state)
 {
     auto iter = idToConsumerMap.find(device->id);

--- a/src/common/core/GridConnection/GridConnection.hpp
+++ b/src/common/core/GridConnection/GridConnection.hpp
@@ -25,6 +25,7 @@ struct IGridConsumer
     virtual void gridDisconnected(bool ownerChanged) = 0;
     virtual std::string gridGetCurrentDeviceId() = 0;
     virtual std::string gridGetLastDeviceId(bool owned) = 0;
+    virtual void setLastDeviceId(std::string id) = 0;
     virtual void gridButtonEvent(int x, int y, bool state) = 0;
     virtual void encDeltaEvent(int n, int d) = 0;
     virtual Grid* gridGetDevice() = 0;
@@ -43,6 +44,7 @@ struct GridConnectionManager final
     bool isConnected(std::string id);
     void disconnect(Grid* grid, bool ownerChanged = false);
     void disconnect(IGridConsumer* consumer, bool ownerChanged = false);
+    void toggleConnection(Grid* grid, IGridConsumer* consumer);
 
     void dispatchButtonMessage(MonomeDevice* device, int x, int y, bool state);
     void dispatchEncDeltaMessage(MonomeDevice* device, int n, int d);

--- a/src/common/core/GridConnection/GridConnectionMenu.cpp
+++ b/src/common/core/GridConnection/GridConnectionMenu.cpp
@@ -3,7 +3,7 @@
 
 using namespace rack;
 
-struct NewConnectGridItem : rack::ui::MenuItem
+struct ConnectGridItem : rack::ui::MenuItem
 {
     Grid* grid;
     IGridConsumer* consumer;
@@ -15,9 +15,10 @@ struct NewConnectGridItem : rack::ui::MenuItem
         {
             auto thisGrid = grid;
             auto thisConsumer = consumer;
-            
-            actionQueue->push([thisGrid, thisConsumer]()
-                { GridConnectionManager::get().connect(thisGrid, thisConsumer); });
+
+            actionQueue->push([thisGrid, thisConsumer]() {
+                GridConnectionManager::get().toggleConnection(thisGrid, thisConsumer);
+            });
         }
     }
 };
@@ -30,11 +31,9 @@ void menuUserReacquireGrid(IGridConsumer* consumer, std::string lastDeviceId, Ac
         {
             if (actionQueue)
             {
-                actionQueue->push([grid, consumer]()
-                    { 
-                        GridConnectionManager::get().connect(grid, consumer); 
-                    }
-                );
+                actionQueue->push([grid, consumer]() {
+                    GridConnectionManager::get().connect(grid, consumer);
+                });
             }
             return;
         }
@@ -75,7 +74,7 @@ void appendDeviceConnectionMenu(rack::Menu* menu, IGridConsumer* consumer, Actio
             continue;
         }
 
-        auto connectItem = new NewConnectGridItem();
+        auto connectItem = new ConnectGridItem();
         connectItem->text = "└ " + grid->getDevice().type + " (" + grid->getDevice().id + ") ";
 
         auto rightText = "";

--- a/src/common/core/GridConnection/GridConsumerBase.cpp
+++ b/src/common/core/GridConnection/GridConsumerBase.cpp
@@ -46,6 +46,11 @@ std::string GridConsumerBase::gridGetLastDeviceId(bool owned)
     return lastConnectedDeviceId;
 }
 
+void GridConsumerBase::setLastDeviceId(std::string id)
+{
+    lastConnectedDeviceId = id;
+}
+
 Grid* GridConsumerBase::gridGetDevice()
 {
     return gridConnection;
@@ -63,19 +68,6 @@ void GridConsumerBase::userReacquireGrid()
                 return;
             }
         }
-    }
-}
-
-void GridConsumerBase::toggleGridConnection(Grid* grid)
-{
-    if (gridConnection == grid)
-    {
-        GridConnectionManager::get().disconnect(this, true);
-        lastConnectedDeviceId = "";
-    }
-    else
-    {
-        GridConnectionManager::get().connect(grid, this);
     }
 }
 

--- a/src/common/core/GridConnection/GridConsumerBase.hpp
+++ b/src/common/core/GridConnection/GridConsumerBase.hpp
@@ -10,6 +10,7 @@ struct GridConsumerBase : public IGridConsumer
     void gridDisconnected(bool ownerChanged) override;
     std::string gridGetCurrentDeviceId() override;
     std::string gridGetLastDeviceId(bool owned) override;
+    virtual void setLastDeviceId(std::string id) override;
     Grid* gridGetDevice() override;
 
     GridConsumerBase();
@@ -25,6 +26,5 @@ struct GridConsumerBase : public IGridConsumer
     bool connectionOwned;
 
 protected:
-    void toggleGridConnection(Grid* grid);
     Grid* gridConnection;
 };

--- a/src/common/core/LibAVR32Module.cpp
+++ b/src/common/core/LibAVR32Module.cpp
@@ -139,11 +139,6 @@ void LibAVR32Module::encDeltaEvent(int n, int d)
     }
 }
 
-void LibAVR32Module::userToggleGridConnection(Grid* grid)
-{
-    audioThreadActions.push([this, grid]() { this->toggleGridConnection(grid); });
-}
-
 void LibAVR32Module::readSerialMessages()
 {
     uint8_t* msg;

--- a/src/common/core/LibAVR32Module.hpp
+++ b/src/common/core/LibAVR32Module.hpp
@@ -56,7 +56,6 @@ struct LibAVR32Module : rack::engine::Module, GridConsumerBase
     virtual void gridButtonEvent(int x, int y, bool state) override;
     virtual void encDeltaEvent(int n, int d) override;
 
-    void userToggleGridConnection(Grid* grid);
     virtual void readSerialMessages();
     void requestReloadFirmware(bool preserveMemory, const std::string& firmwareName = "");
 
@@ -87,6 +86,8 @@ protected:
 
     // Thread-safe for single-producer, single-consumer
     friend struct TeletypeSceneIO;
+    friend struct LibAVR32ModuleWidget;
+    friend struct USBAJack;
     ActionQueue audioThreadActions;
 };
 

--- a/src/common/core/LibAVR32ModuleWidget.hpp
+++ b/src/common/core/LibAVR32ModuleWidget.hpp
@@ -10,5 +10,4 @@ struct LibAVR32ModuleWidget : rack::app::ModuleWidget
     LibAVR32ModuleWidget();
 
     virtual void appendContextMenu(rack::ui::Menu* menu) override;
-    void appendConnectionMenu(rack::Menu* menu);
 };

--- a/src/common/widgets/USBAJack.hpp
+++ b/src/common/widgets/USBAJack.hpp
@@ -2,6 +2,7 @@
 
 #include "rack.hpp"
 #include "LibAVR32Module.hpp"
+#include "GridConnectionMenu.hpp"
 
 
 struct USBAJack : rack::Switch
@@ -87,8 +88,12 @@ struct USBAJack : rack::Switch
         auto mw = dynamic_cast<LibAVR32ModuleWidget*>(parent);
         if (mw)
         {
-            menu->addChild(new rack::MenuSeparator());
-            mw->appendConnectionMenu(menu);
+            auto m = dynamic_cast<LibAVR32Module*>(mw->module);
+            if (mw)
+            {
+                menu->addChild(new rack::MenuSeparator());
+                appendDeviceConnectionMenu(menu, m, &m->audioThreadActions);
+            }
         }
     }
 };

--- a/src/virtualgrid/VirtualGridModule.cpp
+++ b/src/virtualgrid/VirtualGridModule.cpp
@@ -19,11 +19,32 @@ struct MirrorModeGridConsumer : GridConsumerBase
     void gridConnected(Grid* newConnection) override
     {
         if (newConnection == module)
-        { // don't mirror self
+        {
+            // don't mirror self
             return;
         }
 
         GridConsumerBase::gridConnected(newConnection);
+
+        if (module && newConnection)
+        {
+            // update initial LED state
+            uint8_t leds[64];
+            for (int x_offset = 0; x_offset < 16; x_offset += 8)
+            {
+                for (int y_offset = 0; y_offset < 16; y_offset += 8)
+                {
+                    for (int x = 0; x < 8; x++)
+                    {
+                        for (int y = 0; y < 8; y++)
+                        {
+                            leds[y * 8 + x] = module->ledBuffer[(y_offset + y) * 16 + x_offset + x];
+                        }
+                    }
+                    newConnection->updateQuadrant(x_offset, y_offset, leds);
+                }
+            }
+        }
     }
 
     void gridButtonEvent(int x, int y, bool state) override

--- a/src/virtualgrid/VirtualGridWidget.cpp
+++ b/src/virtualgrid/VirtualGridWidget.cpp
@@ -216,6 +216,15 @@ void VirtualGridWidget::appendContextMenu(Menu * menu)
 
     menu->addChild(createSubmenuItem("Mirror hardware grid", "", [=](Menu *childMenu) {
         appendDeviceConnectionMenu(childMenu, grid->mirrorModeConsumer, &grid->audioThreadActions, true);
+        childMenu->addChild(createMenuItem("Stop mirroring", "",
+            [=]() {
+                if (grid->mirrorModeConsumer) {
+                    GridConnectionManager::get().disconnect(grid->mirrorModeConsumer);
+                    grid->mirrorModeConsumer->setLastDeviceId("");
+                }
+            },
+            !grid->mirrorModeConsumer || grid->mirrorModeConsumer->gridGetDevice() == nullptr
+        ));
     }));
 
     menu->addChild(new MenuSeparator());


### PR DESCRIPTION
* Support disconnecting from mirror mode
* Send the current virtual LED state immediately, for situations where the host doesn't send LED updates frequently (e.g. teletype scripts)